### PR TITLE
Configure CI workflow and fix pyproject.toml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,8 +1,10 @@
-name: Run Tests
-# Run the test suite on pull requests and pushes to main branch
+name: Build and Test
+
 on:
-  pull_request:
   push:
+    branches:
+      - main
+  pull_request:
     branches:
       - main
   schedule:
@@ -10,12 +12,13 @@ on:
 
 jobs:
   test:
+    name: Test and Check
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v4.5.2
@@ -24,20 +27,26 @@ jobs:
       uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v5.1.0
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install hatch
       run: |
         python -m pip install --upgrade pip
         python -m pip install hatch
+
     - name: Run test suite
       run: hatch run +py=${{ matrix.python-version }} test:run
-    # If you use this step and have a private repo- then you will need to get a
-    # token from codecov and
-    # save it as a github secret called CODECOV_TOKEN
+
+    - name: Build package
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+      run: hatch build --clean
+
+    - name: Check package metadata
+      if: matrix.os == 'ubuntu-latest' && matrix.python-version == '3.13'
+      run: hatch run build:twine check dist/*
+
     - name: Upload to codecov
       if: runner.os == 'macOS' && matrix.python-version == '3.13'
       uses: codecov/codecov-action@5a1091511ad55cbe89839c7260b706298ca349f7  # v5.5.1
       with:
-        #token: ${{ secrets.CODECOV_TOKEN }}
         verbose: true
         files: ./coverage.xml
-


### PR DESCRIPTION
This PR sets up the CI workflow in .github/workflows/build.yml as requested in issue #21. It also fixes a formatting error in pyproject.toml authors that was preventing successful builds.